### PR TITLE
Markspot marker #29

### DIFF
--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -12,7 +12,7 @@ export class Map extends Component {
   constructor() {
     super();
     this.state = {
-      loaded: false,
+      loaded: false
     };
     this.handleAddSpotGeo = this.handleAddSpotGeo.bind(this);
     this.renewSpotsWithMap = this.renewSpotsWithMap.bind(this);
@@ -28,15 +28,15 @@ export class Map extends Component {
 
   componentDidUpdate(prevProps, prevState){
     console.log('updated');
-    console.log(<SpotInfo />)
-    const { spots, map, headTo } = this.props
+    // const comp = JSON.stringify(<SpotInfo />)
+    // console.log(JSON.stringify(comp))
+    const { spots, map, headTo, sayHello } = this.props
+    // remove existing marker (we can optimize it later)
     const currentMarkers = document.getElementsByClassName("marker");
-    if (currentMarkers.length > 0) {
-      for (let i = 0; i < currentMarkers.length; i++) {
-        currentMarkers[i].remove();
-      }
+    while (currentMarkers.length > 0) {
+      currentMarkers[0].remove();
     }
-    console.log('spots', spots)
+
     spots.features ?
     spots.features.forEach(function(spot) {
         // create the marker
@@ -50,12 +50,11 @@ export class Map extends Component {
         })
           // create the popup
           var popup = new mapboxgl.Popup()
-          .setText(`Size: ${ spot.properties.size }`);
+          .setHTML('<button onClick=(sayHello())>hello</button>');
           new mapboxgl.Marker(el)
           .setLngLat(spot.geometry.coordinates)
           .setPopup(popup) // sets a popup on this marker
           .addTo(map);
-
       })
       : null
     //check for spots that came back in the props and then create the popups in here
@@ -73,28 +72,12 @@ export class Map extends Component {
   }
 
   render() {
+    // const { spots, map } = this.props
+    // console.log('spots',spots)
+    // console.log('map',map)
     return (
       <div id="map">
         <Loader loaded={this.state.loaded} className="loader" />
-        {
-          //Will Load the markers here so that the component
-          //is used
-          // markers.forEach(spot => {
-          //   let spotInfo = <SpotInfo spot={spot} map={map} />
-
-          //     var el = document.createElement('div');
-          //     el.className = 'marker';
-
-          //     var popup = new mapboxgl.Popup()
-          //     .setHTML(spotInfo);
-
-          //     console.log('popup',popup)
-          //     new mapboxgl.Marker(el)
-          //   .setLngLat(spot.geometry.coordinates)
-          //   .setPopup(popup) // sets a popup on this marker
-          //   .addTo(map);
-          // })
-        }
       </div>
     );
   }
@@ -122,6 +105,9 @@ const mapDispatch = (dispatch) => {
     },
     headTo(spotId){
       dispatch(getHeadingTo(spotId));
+    },
+    sayHello(){
+      console.log('hello')
     }
   };
 };

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -12,7 +12,7 @@ export class Map extends Component {
   constructor() {
     super();
     this.state = {
-      loaded: false
+      loaded: false,
     };
     this.handleAddSpotGeo = this.handleAddSpotGeo.bind(this);
     this.renewSpotsWithMap = this.renewSpotsWithMap.bind(this);
@@ -27,10 +27,8 @@ export class Map extends Component {
   }
 
   componentDidUpdate(prevProps, prevState){
-    console.log('updated');
-    // const comp = JSON.stringify(<SpotInfo />)
-    // console.log(JSON.stringify(comp))
-    const { spots, map, headTo, sayHello } = this.props
+    console.log('*map component updated*');
+    const { spots, map, headTo } = this.props
     // remove existing marker (we can optimize it later)
     const currentMarkers = document.getElementsByClassName("marker");
     while (currentMarkers.length > 0) {
@@ -50,15 +48,13 @@ export class Map extends Component {
         })
           // create the popup
           var popup = new mapboxgl.Popup()
-          .setHTML('<button onClick=(sayHello())>hello</button>');
+          .setHTML('<button onClick=(console.log(`hi`))>hello</button>');
           new mapboxgl.Marker(el)
           .setLngLat(spot.geometry.coordinates)
           .setPopup(popup) // sets a popup on this marker
           .addTo(map);
       })
       : null
-    //check for spots that came back in the props and then create the popups in here
-    //can probably do the same for the markers honestlty
   }
 
   handleAddSpotGeo() {
@@ -105,9 +101,6 @@ const mapDispatch = (dispatch) => {
     },
     headTo(spotId){
       dispatch(getHeadingTo(spotId));
-    },
-    sayHello(){
-      console.log('hello')
     }
   };
 };

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { fetchMap, addSpotOnServer, fetchSpots, fetchAddress, getHeadingTo, mapDirection, longitude, latitude } from '../store';
+import { fetchMap, addSpotOnServer, fetchSpots, getHeadingTo, mapDirection, longitude, latitude } from '../store';
 import Loader from 'react-loader';
 import socket from '../socket';
 import { SpotInfo } from './';
@@ -29,8 +29,8 @@ export class Map extends Component {
   componentDidUpdate(prevProps, prevState){
     console.log('updated');
     console.log(<SpotInfo />)
-    const { spots, map } = this.props
-        const currentMarkers = document.getElementsByClassName("marker");
+    const { spots, map, headTo } = this.props
+    const currentMarkers = document.getElementsByClassName("marker");
     if (currentMarkers.length > 0) {
       for (let i = 0; i < currentMarkers.length; i++) {
         currentMarkers[i].remove();
@@ -44,7 +44,7 @@ export class Map extends Component {
         el.className = 'marker';
         // add event listener
         el.addEventListener("click", () => {
-          getHeadingTo(spot.properties.id)
+          headTo(spot.properties.id)
           mapDirection.setOrigin([longitude, latitude]);
           mapDirection.setDestination(spot.geometry.coordinates);
         })
@@ -101,8 +101,8 @@ const mapDispatch = (dispatch) => {
     renewSpots(map) {
       dispatch(fetchSpots(map));
     },
-    getAddress(coor){
-      dispatch(fetchAddress(coor));
+    headTo(spotId){
+      dispatch(getHeadingTo(spotId));
     }
   };
 };

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -66,8 +66,8 @@ export class Map extends Component {
     console.log('add via marker')
     //location of marker is returned by the .getSource function below
     let spot = {
-      longitude: this.map.getSource('point')._data.features[0].geometry.coordinates[0],
-      latitude: this.map.getSource('point')._data.features[0].geometry.coordinates[1],
+      longitude: this.map.getSource('createdPoint')._data.features[0].geometry.coordinates[0],
+      latitude: this.map.getSource('createdPoint')._data.features[0].geometry.coordinates[1],
     }
     this.props.addSpotMarker(this.map, this.props.id, null, spot) //eventually pass in users default vehicle size
     // this.props.getMap(this);
@@ -105,7 +105,6 @@ const mapDispatch = (dispatch) => {
       dispatch(addSpotOnServerGeo(component, id));
     },
     addSpotMarker(component, id, defaultVehicle, spot){
-      console.log('adding marker:',spot)
       dispatch(addSpotOnServerMarker(component, id, defaultVehicle, spot))
     },
     renewSpots(map) {

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { fetchMap, addSpotOnServer, fetchSpots } from '../store';
 import Loader from 'react-loader';
 import socket from '../socket';
+import { SpotInfo } from './';
 
 export class Map extends Component {
 
@@ -22,6 +23,13 @@ export class Map extends Component {
     socket.on('A Spot Taken', () => {
       this.renewSpotsWihMap();
     })
+  }
+
+  componentDidUpdate(prevProps, prevState){
+    console.log('updated');
+    console.log(<SpotInfo />)
+    //check for spots that came back in the props and then create the popups in here
+    //can probably do the same for the markers honestlty
   }
 
   handleAddSpotGeo() {

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -76,6 +76,25 @@ export class Map extends Component {
     return (
       <div id="map">
         <Loader loaded={this.state.loaded} className="loader" />
+        {
+          //Will Load the markers here so that the component
+          //is used
+          // markers.forEach(spot => {
+          //   let spotInfo = <SpotInfo spot={spot} map={map} />
+
+          //     var el = document.createElement('div');
+          //     el.className = 'marker';
+
+          //     var popup = new mapboxgl.Popup()
+          //     .setHTML(spotInfo);
+
+          //     console.log('popup',popup)
+          //     new mapboxgl.Marker(el)
+          //   .setLngLat(spot.geometry.coordinates)
+          //   .setPopup(popup) // sets a popup on this marker
+          //   .addTo(map);
+          // })
+        }
       </div>
     );
   }

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -27,7 +27,7 @@ export class Map extends Component {
   }
 
   componentDidUpdate(prevProps, prevState){
-    console.log('*map component updated*');
+    console.log('*map component updated* || Adding markers');
     const { spots, map, headTo } = this.props
     // remove existing marker (we can optimize it later)
     const currentMarkers = document.getElementsByClassName("marker");
@@ -35,7 +35,7 @@ export class Map extends Component {
       currentMarkers[0].remove();
     }
 
-    spots.features ?
+    spots.features &&
     spots.features.forEach(function(spot) {
         // create the marker
         var el = document.createElement('div');
@@ -54,7 +54,6 @@ export class Map extends Component {
           .setPopup(popup) // sets a popup on this marker
           .addTo(map);
       })
-      : null
   }
 
   handleAddSpotGeo() {
@@ -68,9 +67,6 @@ export class Map extends Component {
   }
 
   render() {
-    // const { spots, map } = this.props
-    // console.log('spots',spots)
-    // console.log('map',map)
     return (
       <div id="map">
         <Loader loaded={this.state.loaded} className="loader" />

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { fetchMap, addSpotOnServer, fetchSpots } from '../store';
+import { fetchMap, addSpotOnServer, fetchSpots, fetchAddress, getHeadingTo, mapDirection, longitude, latitude } from '../store';
 import Loader from 'react-loader';
 import socket from '../socket';
-import { SpotInfo } from './';
+import { SpotInfo } from './';
+import mapboxgl from 'mapbox-gl';
 
 export class Map extends Component {
 
@@ -14,20 +15,49 @@ export class Map extends Component {
       loaded: false,
     };
     this.handleAddSpotGeo = this.handleAddSpotGeo.bind(this);
-    this.renewSpotsWihMap = this.renewSpotsWihMap.bind(this);
+    this.renewSpotsWithMap = this.renewSpotsWithMap.bind(this);
   }
 
   componentDidMount() {
     this.props.getMap(this);
     this.props.onRef(this);
     socket.on('A Spot Taken', () => {
-      this.renewSpotsWihMap();
+      this.renewSpotsWithMap();
     })
   }
 
   componentDidUpdate(prevProps, prevState){
     console.log('updated');
     console.log(<SpotInfo />)
+    const { spots, map } = this.props
+        const currentMarkers = document.getElementsByClassName("marker");
+    if (currentMarkers.length > 0) {
+      for (let i = 0; i < currentMarkers.length; i++) {
+        currentMarkers[i].remove();
+      }
+    }
+    console.log('spots', spots)
+    spots.features ?
+    spots.features.forEach(function(spot) {
+        // create the marker
+        var el = document.createElement('div');
+        el.className = 'marker';
+        // add event listener
+        el.addEventListener("click", () => {
+          getHeadingTo(spot.properties.id)
+          mapDirection.setOrigin([longitude, latitude]);
+          mapDirection.setDestination(spot.geometry.coordinates);
+        })
+          // create the popup
+          var popup = new mapboxgl.Popup()
+          .setText(`Size: ${ spot.properties.size }`);
+          new mapboxgl.Marker(el)
+          .setLngLat(spot.geometry.coordinates)
+          .setPopup(popup) // sets a popup on this marker
+          .addTo(map);
+
+      })
+      : null
     //check for spots that came back in the props and then create the popups in here
     //can probably do the same for the markers honestlty
   }
@@ -37,7 +67,7 @@ export class Map extends Component {
     // this.props.getMap(this);
   }
 
-  renewSpotsWihMap() {
+  renewSpotsWithMap() {
     const { renewSpots, map } = this.props
     renewSpots(map);
   }
@@ -70,6 +100,9 @@ const mapDispatch = (dispatch) => {
     },
     renewSpots(map) {
       dispatch(fetchSpots(map));
+    },
+    getAddress(coor){
+      dispatch(fetchAddress(coor));
     }
   };
 };

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { fetchMap, addSpotOnServer, fetchSpots, getHeadingTo, mapDirection, longitude, latitude } from '../store';
+import { fetchMap, addSpotOnServerGeo, addSpotOnServerMarker, fetchSpots, getHeadingTo, mapDirection, longitude, latitude } from '../store';
 import Loader from 'react-loader';
 import socket from '../socket';
 import { SpotInfo } from './';
@@ -57,7 +57,19 @@ export class Map extends Component {
   }
 
   handleAddSpotGeo() {
-    this.props.addSpot(this.map, this.props.id) //eventually pass in users default vehicle size
+    console.log('add via geo')
+    this.props.addSpotGeo(this.map, this.props.id, null) //eventually pass in users default vehicle size
+    // this.props.getMap(this);
+  }
+
+  handleAddSpotMarker(){
+    console.log('add via marker')
+    //location of marker is returned by the .getSource function below
+    let spot = {
+      longitude: this.map.getSource('point')._data.features[0].geometry.coordinates[0],
+      latitude: this.map.getSource('point')._data.features[0].geometry.coordinates[1],
+    }
+    this.props.addSpotMarker(this.map, this.props.id, null, spot) //eventually pass in users default vehicle size
     // this.props.getMap(this);
   }
 
@@ -89,8 +101,12 @@ const mapDispatch = (dispatch) => {
       const thunk = fetchMap(component);
       dispatch(thunk);
     },
-    addSpot(component, id){
-      dispatch(addSpotOnServer(component, id));
+    addSpotGeo(component, id){
+      dispatch(addSpotOnServerGeo(component, id));
+    },
+    addSpotMarker(component, id, defaultVehicle, spot){
+      console.log('adding marker:',spot)
+      dispatch(addSpotOnServerMarker(component, id, defaultVehicle, spot))
     },
     renewSpots(map) {
       dispatch(fetchSpots(map));

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -8,3 +8,4 @@
 export {default as Main} from './Main';
 export {default as UserHome} from './User-home';
 export {Login, Signup} from './Auth-form';
+export {SpotInfo} from './spot-info';

--- a/client/components/spot-info.js
+++ b/client/components/spot-info.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
 
 export const SpotInfo  = (props) => {
-    return ( <p>marker! </p>)
+    return ( <p>marker!</p>)
 }

--- a/client/components/spot-info.js
+++ b/client/components/spot-info.js
@@ -1,0 +1,5 @@
+import React, { Component } from 'react';
+
+export const SpotInfo  = (props) => {
+    return ( <p>marker! </p>)
+}

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { takeSpot, updateSpotsTaken } from '../store';
+import { takeSpot, updateSpotsTaken, addSpotOnServer } from '../store';
 import socket from '../socket';
 import Map from './Map';
 import List from './List';
@@ -19,10 +19,16 @@ export class UserHome extends Component {
     this.handleSpotTaken = this.handleSpotTaken.bind(this);
     this.setMapView = this.setMapView.bind(this);
     this.triggerHandleAddSpotGeo = this.triggerHandleAddSpotGeo.bind(this);
+    this.triggerHandleAddSpotMarker = this.triggerHandleAddSpotMarker.bind(this);
   }
   triggerHandleAddSpotGeo() {
     //to trigger function in child component from parent using ref
     this.map.handleAddSpotGeo();
+  }
+
+  triggerHandleAddSpotMarker(){
+    //same as above
+    this.map.handleAddSpotMarker();
   }
 
   componentDidMount() {
@@ -46,7 +52,7 @@ export class UserHome extends Component {
 
   render() {
     const { email } = this.props;
-    const { handleSpotTaken, setMapView, triggerHandleAddSpotGeo } = this;
+    const { handleSpotTaken, setMapView, triggerHandleAddSpotGeo, triggerHandleAddSpotMarker } = this;
     const { showNotification, mapView } = this.state;
     return (
       <div className="container">
@@ -55,6 +61,7 @@ export class UserHome extends Component {
           <div className="col-md-4">
             <button className="btn btn-default" onClick={handleSpotTaken}>Mark Spot Taken</button>
             <button className="btn btn-default" onClick={triggerHandleAddSpotGeo}>Open Spot Here</button>
+            <button className="btn btn-default" onClick={triggerHandleAddSpotMarker}>Open Spot at Marker</button>
             {
               showNotification.isShow && <p className="alert alert-warning">{showNotification.message}</p>
             }
@@ -88,6 +95,9 @@ const mapDispatch = (dispatch) => {
     },
     updateUserSpotsTaken() {
       dispatch(updateSpotsTaken());
+    },
+    createSpot(component, id){
+      dispatch(addSpotOnServer(component, id));
     }
   };
 };

--- a/client/store/map.js
+++ b/client/store/map.js
@@ -19,9 +19,11 @@ const getUserLocation = function (options) {
 // This function is not fully implemented
 const createDraggablePoint = (map, event) => {
   console.log('creating draggable point')
+  console.log(event)
   // Holds mousedown state for events. if this
   // flag is active, we move the point on `mousemove`.
   var isDragging;
+  var coords = event.lngLat;
 
   // Is the cursor over a point? if this
   // flag is active, we listen for a mousedown event.
@@ -35,8 +37,7 @@ const createDraggablePoint = (map, event) => {
           "type": "Feature",
           "geometry": {
               "type": "Point",
-              // "coordinates": [event.lng, event.lat]
-              "coordinates": [-74.00880017963634, 40.218755763900845]
+              "coordinates": [coords.lng, coords.lat]
           }
       }]
   };

--- a/client/store/map.js
+++ b/client/store/map.js
@@ -18,6 +18,17 @@ const getUserLocation = function (options) {
 
 // This function is not fully implemented
 const createDraggablePoint = (map, event) => {
+
+  //First we check to see if user is trying to create
+  //another point on map and instead of dragging current one
+  let exits = map.getStyle().layers.find((layer) => layer.id === 'createdPoint')
+  //If so, we remove the point so we can create a new one
+  //note we need to remove the source as well
+  if (exits) {
+    map.removeLayer(exits.id)
+    map.removeSource(exits.id)
+  }
+
   // Holds mousedown state for events. if this
   // flag is active, we move the point on `mousemove`.
   var isDragging;
@@ -63,7 +74,7 @@ const createDraggablePoint = (map, event) => {
       // Update the Point feature in `geojson` coordinates
       // and call setData to the source layer `point` on it.
       geojson.features[0].geometry.coordinates = [coords.lng, coords.lat];
-      map.getSource('point').setData(geojson);
+      map.getSource('createdPoint').setData(geojson);
   }
 
   function onUp(e) {
@@ -82,15 +93,15 @@ const createDraggablePoint = (map, event) => {
   }
 
   // Add a single point to the map
-  map.addSource('point', {
+  map.addSource('createdPoint', {
       "type": "geojson",
       "data": geojson
   });
 
   map.addLayer({
-      "id": "point",
+      "id": "createdPoint",
       "type": "circle",
-      "source": "point",
+      "source": "createdPoint",
       "paint": {
           "circle-radius": 10,
           "circle-color": "#3887be"
@@ -98,15 +109,15 @@ const createDraggablePoint = (map, event) => {
   });
 
   // When the cursor enters a feature in the point layer, prepare for dragging.
-  map.on('mouseenter', 'point', function() {
-      map.setPaintProperty('point', 'circle-color', '#3bb2d0');
+  map.on('mouseenter', 'createdPoint', function() {
+      map.setPaintProperty('createdPoint', 'circle-color', '#3bb2d0');
       canvas.style.cursor = 'move';
       isCursorOverPoint = true;
       map.dragPan.disable();
   });
 
-  map.on('mouseleave', 'point', function() {
-      map.setPaintProperty('point', 'circle-color', '#3887be');
+  map.on('mouseleave', 'createdPoint', function() {
+      map.setPaintProperty('createdPoint', 'circle-color', '#3887be');
       canvas.style.cursor = '';
       isCursorOverPoint = false;
       map.dragPan.enable();
@@ -209,10 +220,10 @@ export const fetchMap = (component) => {
         // see helper function above
         var firstClick = true;
         component.map.on('click', function (e) {
-          if (firstClick) {
+          // if (firstClick) {
             createDraggablePoint(component.map, e)
-            firstClick = false
-          }
+          //   firstClick = false
+          // }
         });
 
 

--- a/client/store/map.js
+++ b/client/store/map.js
@@ -16,8 +16,8 @@ const getUserLocation = function (options) {
   });
 };
 
-
-const createDraggablePoint = (map) => {
+// This function is not fully implemented
+const createDraggablePoint = (map, event) => {
   console.log('creating draggable point')
   // Holds mousedown state for events. if this
   // flag is active, we move the point on `mousemove`.
@@ -35,11 +35,11 @@ const createDraggablePoint = (map) => {
           "type": "Feature",
           "geometry": {
               "type": "Point",
-              "coordinates": [-74.01267388943265, 40.217866968788115]
+              // "coordinates": [event.lng, event.lat]
+              "coordinates": [-74.00880017963634, 40.218755763900845]
           }
       }]
   };
-
   function mouseDown() {
       if (!isCursorOverPoint) return;
 
@@ -81,7 +81,7 @@ const createDraggablePoint = (map) => {
       map.off('mousemove', onMove);
   }
 
-  map.on('load', function() {
+  // map.on('load', function() {
 
       // Add a single point to the map
       map.addSource('point', {
@@ -115,7 +115,7 @@ const createDraggablePoint = (map) => {
       });
 
       map.on('mousedown', mouseDown);
-  });
+  // });
 }
 
 
@@ -210,11 +210,15 @@ export const fetchMap = (component) => {
         // add draggable point
         // used for creating spots on demand
         // see helper function above
-        createDraggablePoint(component.map)
+        var firstClick = true;
         component.map.on('click', function (e) {
+          if (firstClick) {
+          createDraggablePoint(component.map, e)
             console.log('clicking:'+
                 // e.lngLat is the longitude, latitude geographical position of the event
                 JSON.stringify(e.lngLat));
+          }
+          firstClick = false
         });
 
 

--- a/client/store/map.js
+++ b/client/store/map.js
@@ -18,8 +18,6 @@ const getUserLocation = function (options) {
 
 // This function is not fully implemented
 const createDraggablePoint = (map, event) => {
-  console.log('creating draggable point')
-  console.log(event)
   // Holds mousedown state for events. if this
   // flag is active, we move the point on `mousemove`.
   var isDragging;
@@ -82,41 +80,38 @@ const createDraggablePoint = (map, event) => {
       map.off('mousemove', onMove);
   }
 
-  // map.on('load', function() {
+  // Add a single point to the map
+  map.addSource('point', {
+      "type": "geojson",
+      "data": geojson
+  });
 
-      // Add a single point to the map
-      map.addSource('point', {
-          "type": "geojson",
-          "data": geojson
-      });
+  map.addLayer({
+      "id": "point",
+      "type": "circle",
+      "source": "point",
+      "paint": {
+          "circle-radius": 10,
+          "circle-color": "#3887be"
+      }
+  });
 
-      map.addLayer({
-          "id": "point",
-          "type": "circle",
-          "source": "point",
-          "paint": {
-              "circle-radius": 10,
-              "circle-color": "#3887be"
-          }
-      });
+  // When the cursor enters a feature in the point layer, prepare for dragging.
+  map.on('mouseenter', 'point', function() {
+      map.setPaintProperty('point', 'circle-color', '#3bb2d0');
+      canvas.style.cursor = 'move';
+      isCursorOverPoint = true;
+      map.dragPan.disable();
+  });
 
-      // When the cursor enters a feature in the point layer, prepare for dragging.
-      map.on('mouseenter', 'point', function() {
-          map.setPaintProperty('point', 'circle-color', '#3bb2d0');
-          canvas.style.cursor = 'move';
-          isCursorOverPoint = true;
-          map.dragPan.disable();
-      });
+  map.on('mouseleave', 'point', function() {
+      map.setPaintProperty('point', 'circle-color', '#3887be');
+      canvas.style.cursor = '';
+      isCursorOverPoint = false;
+      map.dragPan.enable();
+  });
 
-      map.on('mouseleave', 'point', function() {
-          map.setPaintProperty('point', 'circle-color', '#3887be');
-          canvas.style.cursor = '';
-          isCursorOverPoint = false;
-          map.dragPan.enable();
-      });
-
-      map.on('mousedown', mouseDown);
-  // });
+  map.on('mousedown', mouseDown);
 }
 
 
@@ -214,12 +209,9 @@ export const fetchMap = (component) => {
         var firstClick = true;
         component.map.on('click', function (e) {
           if (firstClick) {
-          createDraggablePoint(component.map, e)
-            console.log('clicking:'+
-                // e.lngLat is the longitude, latitude geographical position of the event
-                JSON.stringify(e.lngLat));
+            createDraggablePoint(component.map, e)
+            firstClick = false
           }
-          firstClick = false
         });
 
 

--- a/client/store/map.js
+++ b/client/store/map.js
@@ -39,6 +39,7 @@ const createDraggablePoint = (map, event) => {
           }
       }]
   };
+
   function mouseDown() {
       if (!isCursorOverPoint) return;
 
@@ -93,7 +94,7 @@ const createDraggablePoint = (map, event) => {
       "paint": {
           "circle-radius": 10,
           "circle-color": "#3887be"
-      }
+      },
   });
 
   // When the cursor enters a feature in the point layer, prepare for dragging.

--- a/client/store/street-spots.js
+++ b/client/store/street-spots.js
@@ -10,7 +10,6 @@ import store, { getHeadingTo, mapDirection, longitude, latitude } from './';
  * ACTION TYPES
  */
  const GET_SPOTS = 'GET_SPOTS';
- const GET_ADDRESS = 'GET_ADDRESS'
 
  /**
  * INITIAL STATE
@@ -25,7 +24,7 @@ const getSpots = spots => ({type: GET_SPOTS, spots});
 /**
  * THUNK CREATORS
  */
-export const fetchAddress = (coor) => {
+const fetchAddress = (coor) => {
   const [lat, lng] = coor;
   return axios.get('https://api.mapbox.com/geocoding/v5/mapbox.places/' + lat + ',' + lng + '.json?access_token=' + mapboxgl.accessToken)
   .then(res => res.data)
@@ -51,6 +50,9 @@ export const fetchSpots = (map) =>
             currentMarkers[i].remove();
           }
         }
+        //This has been changed so that we're only returning the spots
+        //and their addresses appended onto the object in the store
+        //markers are now created in the front-end component
         spots.features.forEach(function(spot) {
             fetchAddress(spot.geometry.coordinates)
             .then( place => spot.place_name = place)
@@ -120,8 +122,6 @@ export default function (state = defaultSpots, action) {
   switch (action.type) {
     case GET_SPOTS:
       return action.spots;
-    case GET_ADDRESS:
-      return action.spots
     default:
       return state;
   }

--- a/client/store/street-spots.js
+++ b/client/store/street-spots.js
@@ -105,12 +105,16 @@ export const takeSpot = (id, map) =>
     .then(result => result.data)
     .then( reporter => {
       dispatch(fetchSpots(map));
+      if (document.getElementsByClassName("mapboxgl-popup").length > 0) {
+        document.getElementsByClassName("mapboxgl-popup")[0].remove();
+      }
       console.log(reporter);
       if (reporter.socketId) {
         socket.emit('spot-taken-online', reporter.socketId);
       } else {
         socket.emit('spot-taken-offline', reporter.id);
       }
+      mapDirection.removeRoutes();
     })
     .catch( err => console.log(err));
 

--- a/client/store/street-spots.js
+++ b/client/store/street-spots.js
@@ -83,7 +83,7 @@ export const fetchSpots = (map) =>
       })
       .catch(err => console.log(err));
 
-export const addSpotOnServer = (map, userId, defaultVehicle) =>
+export const addSpotOnServerGeo = (map, userId, defaultVehicle) =>
   dispatch =>
    getUserLocation()
       .then( position => {
@@ -92,6 +92,13 @@ export const addSpotOnServer = (map, userId, defaultVehicle) =>
         return axios.post(`/api/streetspots/${ userId }`, spot)})
       .then( () => dispatch(fetchSpots(map)))
       .catch(err => console.log(err));
+
+export const addSpotOnServerMarker = (map, userId, defaultVehicle, spot) =>
+  dispatch =>
+    axios.post(`/api/streetspots/${ userId }`, spot)
+        .then( () => dispatch(fetchSpots(map)))
+        .catch(err => console.log(err))
+
 
 export const deleteSpotOnServer = (spotId) =>
   dispatch =>

--- a/client/store/street-spots.js
+++ b/client/store/street-spots.js
@@ -10,6 +10,7 @@ import store, { getHeadingTo, mapDirection, longitude, latitude } from './';
  * ACTION TYPES
  */
  const GET_SPOTS = 'GET_SPOTS';
+ const GET_ADDRESS = 'GET_ADDRESS'
 
  /**
  * INITIAL STATE
@@ -24,7 +25,7 @@ const getSpots = spots => ({type: GET_SPOTS, spots});
 /**
  * THUNK CREATORS
  */
-const fetchAddress = (coor) => {
+export const fetchAddress = (coor) => {
   const [lat, lng] = coor;
   return axios.get('https://api.mapbox.com/geocoding/v5/mapbox.places/' + lat + ',' + lng + '.json?access_token=' + mapboxgl.accessToken)
   .then(res => res.data)
@@ -50,29 +51,32 @@ export const fetchSpots = (map) =>
             currentMarkers[i].remove();
           }
         }
-
         spots.features.forEach(function(spot) {
-            // create the marker
-            var el = document.createElement('div');
-            el.className = 'marker';
-            // add event listener
-            el.addEventListener("click", () => {
-              dispatch(getHeadingTo(spot.properties.id))
-              mapDirection.setOrigin([longitude, latitude]);
-              mapDirection.setDestination(spot.geometry.coordinates);
-            })
             fetchAddress(spot.geometry.coordinates)
-            .then( place => {
-              spot.place_name = place;
-              // create the popup
-              var popup = new mapboxgl.Popup()
-              .setText(`Size: ${ spot.properties.size }`);
-              new mapboxgl.Marker(el)
-              .setLngLat(spot.geometry.coordinates)
-              .setPopup(popup) // sets a popup on this marker
-              .addTo(map);
-            })
+            .then( place => spot.place_name = place)
           });
+        // spots.features.forEach(function(spot) {
+        //     // create the marker
+        //     var el = document.createElement('div');
+        //     el.className = 'marker';
+        //     // add event listener
+        //     el.addEventListener("click", () => {
+        //       dispatch(getHeadingTo(spot.properties.id))
+        //       mapDirection.setOrigin([longitude, latitude]);
+        //       mapDirection.setDestination(spot.geometry.coordinates);
+        //     })
+        //     fetchAddress(spot.geometry.coordinates)
+        //     .then( place => {
+        //       spot.place_name = place;
+        //       // create the popup
+        //       var popup = new mapboxgl.Popup()
+        //       .setText(`Size: ${ spot.properties.size }`);
+        //       new mapboxgl.Marker(el)
+        //       .setLngLat(spot.geometry.coordinates)
+        //       .setPopup(popup) // sets a popup on this marker
+        //       .addTo(map);
+        //     })
+        //   });
         return dispatch(getSpots(spots || defaultSpots));
       })
       .catch(err => console.log(err));
@@ -116,6 +120,8 @@ export default function (state = defaultSpots, action) {
   switch (action.type) {
     case GET_SPOTS:
       return action.spots;
+    case GET_ADDRESS:
+      return action.spots
     default:
       return state;
   }

--- a/index.html
+++ b/index.html
@@ -19,22 +19,24 @@
   <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.1/mapbox-gl-geocoder.css'
     type='text/css' />
   <div id="app"></div>
+  <!-- **ONLY FOR TESTING** -->
   <pre id='coordinates' class='coordinates'></pre>
-<style>
-.coordinates {
-    background: rgba(0,0,0,0.5);
-    color: #fff;
-    position: absolute;
-    bottom: 10px;
-    left: 10px;
-    padding:5px 10px;
-    margin: 0;
-    font-size: 11px;
-    line-height: 18px;
-    border-radius: 3px;
-    display: none;
-}
-</style>
+  <style>
+  .coordinates {
+      background: rgba(0,0,0,0.5);
+      color: #fff;
+      position: absolute;
+      bottom: 10px;
+      left: 10px;
+      padding:5px 10px;
+      margin: 0;
+      font-size: 11px;
+      line-height: 18px;
+      border-radius: 3px;
+      display: none;
+  }
+  </style>
+<!-- **ONLY FOR TESTING** -->
 
   <script src='/dist/bundle.js'></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,22 @@
   <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.1/mapbox-gl-geocoder.css'
     type='text/css' />
   <div id="app"></div>
+  <pre id='coordinates' class='coordinates'></pre>
+<style>
+.coordinates {
+    background: rgba(0,0,0,0.5);
+    color: #fff;
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    padding:5px 10px;
+    margin: 0;
+    font-size: 11px;
+    line-height: 18px;
+    border-radius: 3px;
+    display: none;
+}
+</style>
 
   <script src='/dist/bundle.js'></script>
 </body>

--- a/server/db/models/seed.js
+++ b/server/db/models/seed.js
@@ -37,7 +37,7 @@ module.exports = (User, Streetspots) => {
       streetspots.map((location) => Streetspots.create(location))
     );
   })
-  .then(([_lot1, _lot2, _lot3, _lot4, _lot5, _lot6, _lot7, _lot8, _lot9, _lot10]) => {
+  .then(([_lot1, _lot2, _lot3, _lot4, _lot5, _lot6, _lot7, _lot8, _lot9, _lot10, _lot11, _lot12, _lot13, _lot14]) => {
     return Promise.all([
       _lot1.setUser(user1),
       _lot2.setUser(user1),
@@ -48,7 +48,11 @@ module.exports = (User, Streetspots) => {
       _lot7.setUser(user2),
       _lot8.setUser(user2),
       _lot9.setUser(user1),
-      _lot10.setUser(user1)
+      _lot10.setUser(user1),
+      _lot11.setUser(user1),
+      _lot12.setUser(user2),
+      _lot13.setUser(user2),
+      _lot14.setUser(user1)
     ])
   .then(() => console.log(chalk.green('DB is synced and seeded')));
   })

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -28,7 +28,7 @@ module.exports = (io, User) => {
       User.findById(reporterId)
         .then(user => {
           user.spotsTaken += 1;
-          console.log(user);
+          //console.log(user);
           return user.save();
         })
         .catch(err => console.log(err));


### PR DESCRIPTION
-Moved marker creation for current spots from the store into the map component (to avoid creating too much HTML in the store). This happens after initial fetch once map is loaded with componentDidUpdate
- User can now click on the map to create a marker
- Added functionality so marker is completely draggable
- User can override marker click with a subsequent marker click in another area of the map
- User can now create an 'open spot' via the marker
- Fixed a bug with creating a spot via Geo location
- Added small lat/long overlay in bottom right corner for front end testing (this can be removed)